### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Caiyun Weather MCP Server
 
+[![MCP status](https://mcpvitals.com/badge/1ff580ca08.svg)](https://mcpvitals.com/status/1ff580ca08)
+
 ## Hosted Server
 
 Caiyun Weather provides a hosted Streamable HTTP MCP server, so you can use


### PR DESCRIPTION
Hi — since this endpoint is operated by Caiyun rather than self-hosted by users, a public uptime badge is effectively a reliability signal for your own service.

This adds one that runs the real MCP handshake against `mcp-weather.caiyunapp.com/mcp` and links to a public status page with uptime and latency history. Healthy with 5 tools now.

If you'd rather run the monitoring yourselves, the same check is available as a free CLI (`npx @mcpvitals/cli check <url>`) — no hard feelings if you close this.

---
*Disclosure: I build MCP Vitals, the service behind this badge — so I have an interest here. I also used an AI assistant to help prepare this PR. The check is real and reproducible without me: `npx @mcpvitals/cli check <your-endpoint>`. Close it freely if it isn't a fit.*